### PR TITLE
Update app/src/main/java/org/bostwickenator/googlephotos/WifiSetupAct…

### DIFF
--- a/app/src/main/java/org/bostwickenator/googlephotos/WifiSetupActivity.java
+++ b/app/src/main/java/org/bostwickenator/googlephotos/WifiSetupActivity.java
@@ -124,7 +124,6 @@ public class WifiSetupActivity extends Activity {
                         summary = res.getString(R.string.connectionStateConnecting);
                         break;
                     default:
-                        res.getString(0, "test");
                         summary = res.getString(R.string.connectionStateWifiEnabled);
                 }
             }


### PR DESCRIPTION
…ivity.java

Removed crashing line of test code.
My camera network state is in IDLE state when STGUploader is the first application run.  A fix to get my camera into a different state when the app starts is to first run Open-Memories to "prime" the wifi.